### PR TITLE
Refetch when Navigating to the same View

### DIFF
--- a/PinkSea.Frontend/src/components/TimeLine.vue
+++ b/PinkSea.Frontend/src/components/TimeLine.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeMount, ref } from 'vue'
+import { onBeforeMount, ref, watch } from 'vue'
 import TimeLineOekakiCard from '@/components/TimeLineOekakiCard.vue'
 import type { Oekaki } from '@/models/oekaki'
 import type { GenericTimelineQueryOutput, Queries } from '@atcute/client/lexicons'
@@ -16,7 +16,7 @@ import Intersector from '@/components/Intersector.vue'
 
   const oekaki = ref<Oekaki[] | null>(null);
 
-  onBeforeMount(async () => {
+  watch(() => props.xrpcParams,(async () => {
     const opts = props.xrpcParams !== undefined
       ? { params: { ...props.xrpcParams } }
       : {};
@@ -24,7 +24,7 @@ import Intersector from '@/components/Intersector.vue'
     // @ts-expect-error I do not understand TypeScript but xrpcParams is of the params type of the endpoint.
     const { data } = await xrpc.get(props.endpoint, opts);
     oekaki.value = (data as GenericTimelineQueryOutput).oekaki;
-  });
+  }), { immediate: true });
 
   const loadMore = async () => {
     if (oekaki.value === null || oekaki.value.length < 1 || !keepLoading.value) {

--- a/PinkSea.Frontend/src/views/UserView.vue
+++ b/PinkSea.Frontend/src/views/UserView.vue
@@ -2,17 +2,17 @@
 
 import TimeLine from '@/components/TimeLine.vue'
 import PanelLayout from '@/layouts/PanelLayout.vue'
-import { computed, onBeforeMount, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { xrpc } from '@/api/atproto/client'
 import { useRoute } from 'vue-router'
 
 const handle = ref<string>("");
 const route = useRoute();
 
-onBeforeMount(async () => {
+watch(() => route.params.did, async () => {
   const { data } = await xrpc.get("com.shinolabs.pinksea.getHandleFromDid", { params: { did: route.params.did as string }});
   handle.value = data.handle;
-});
+}, {immediate: true});
 
 const bskyUrl = computed(() => {
   return `https://bsky.app/profile/${route.params.did}`;


### PR DESCRIPTION
Fix #23, The issue is that when navigating to the same view, `onBeforeMount` wasn't called, so both the timeline and the user handle weren't re-fetched. In this fix, fetching user handle and timeline now done through using `watch` instead