### PR TITLE
Improve: Show full name language value on language selector.

### DIFF
--- a/PinkSea.Frontend/src/intl/i18n.ts
+++ b/PinkSea.Frontend/src/intl/i18n.ts
@@ -8,24 +8,31 @@ import It from '@/intl/translations/it'
 
 export default {
   en: {
-    translation: En
+    name: "English",
+    translation: En,
   },
   id: {
-    translation: Id
+    name: "Bahasa Indonesia",
+    translation: Id,
   },
   pl: {
-    translation: Pl
+    name: "Polski",
+    translation: Pl,
   },
   ja: {
-    translation: Ja
+    name: "日本語",
+    translation: Ja,
   },
   de: {
-    translation: De
+    name: "Deutsch",
+    translation: De,
   },
   fr: {
-    translation: Fr
+    name: "Français",
+    translation: Fr,
   },
   it: {
-    translation: It
-  }
+    name: "Italiano",
+    translation: It,
+  },
 };

--- a/PinkSea.Frontend/src/views/SettingsView.vue
+++ b/PinkSea.Frontend/src/views/SettingsView.vue
@@ -19,7 +19,7 @@ watch(persistedStore, () => {
         <legend>{{ $t("settings.category_general") }}</legend>
         <span style="margin-right: 10px;">{{ $t("settings.general_language") }}</span>
         <select v-model="persistedStore.lang" >
-          <option v-for="lang in Object.keys(I18n)" v-bind:key="lang" :value="lang">{{ lang }}</option>
+          <option v-for="(lang, code) in I18n" :key="code" :value="code">{{ lang.name }}</option>
         </select>
       </fieldset>
       <fieldset>


### PR DESCRIPTION
currentry, setting's language selector showing language code.
so it will be clear show full name value.

before:
![image](https://github.com/user-attachments/assets/11de3eb4-4fd6-4a96-b487-6f175870e1eb)

after:
![image](https://github.com/user-attachments/assets/1a289a31-7ae3-44d1-9b60-f7cbb15a6edc)

note: if mistakes name, please fix to each translator. 🙇🏼‍♂️