### PR TITLE
fix: get rid of the brush smearing in tegaki.js (and some other cursor oddities)

### DIFF
--- a/PinkSea.Frontend/src/api/tegaki/tegaki.js
+++ b/PinkSea.Frontend/src/api/tegaki/tegaki.js
@@ -4051,7 +4051,9 @@ export var Tegaki = {
     var events, x, y, tool, ts, p;
 
     if (Tegaki.cursor) {
-      TegakiCursor.render(e.clientX, e.clientY);
+      TegakiCursor.render(
+        e.clientX + window.pageXOffset,
+        e.clientY + window.pageYOffset);
     }
 
     if (e.mozInputSource !== undefined) {

--- a/PinkSea.Frontend/src/api/tegaki/tegaki.js
+++ b/PinkSea.Frontend/src/api/tegaki/tegaki.js
@@ -1769,7 +1769,7 @@ var TegakiCursor = {
   },
 
   clear: function() {
-    this.cursorCtx.clearRect(this.lastX, this.lastY, this.lastSize, this.lastSize);
+    this.cursorCtx.clearRect(this.lastX - 5, this.lastY - 5, this.lastSize + 10, this.lastSize + 10);
   },
 
   clearAll: function() {


### PR DESCRIPTION
## Arc on macOS

master:
<img width="1439" alt="Zrzut ekranu 2024-11-16 o 10 28 38" src="https://github.com/user-attachments/assets/b96c0d12-d560-4b2c-8838-34cbe6f2a6f8">

this branch:
<img width="1438" alt="Zrzut ekranu 2024-11-16 o 10 34 22" src="https://github.com/user-attachments/assets/49d760db-0e53-4957-97ff-dae554189036">

## Safari on macOS

master:
<img width="1144" alt="Zrzut ekranu 2024-11-16 o 10 29 54" src="https://github.com/user-attachments/assets/af11b35c-c8e4-4242-afd9-5f5122f743fe">

this branch:
<img width="336" alt="Zrzut ekranu 2024-11-16 o 10 32 38" src="https://github.com/user-attachments/assets/2b3fe03b-e9fb-4343-824a-920223182a3c">